### PR TITLE
Use native strip method to work with native strings in py 2.7 and py 3

### DIFF
--- a/pdftables/pdftables.py
+++ b/pdftables/pdftables.py
@@ -541,7 +541,7 @@ def page_to_tables(page, extend_y=False, hints=[], atomise=False):
     if atomise:
         tmp_table = []
         for row in table_array:
-            stripped_row = list(map(str.strip,row))
+            stripped_row = [elem.strip() for elem in row]
             tmp_table.append(stripped_row)
         table_array = tmp_table
 


### PR DESCRIPTION
`str.strip` will not work on unicode strings. Using the `.strip` method on the string will work on Python 2 and Python 3 strings.